### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/phpMyFAQ/www.phpmyfaq.de/security/code-scanning/2](https://github.com/phpMyFAQ/www.phpmyfaq.de/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow, specifying the minimal permissions required for the job. The least privilege for most CI test jobs is `contents: read`, which allows steps such as checkout and does not allow the workflow to modify the repo. The Codecov upload already uses an external token, so no extra permissions are needed for that. Add the following block before `jobs:` (at the workflow root):

```yaml
permissions:
  contents: read
```

This limits `GITHUB_TOKEN` to read-only access to repository contents for all jobs in the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
