### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/phpMyFAQ/www.phpmyfaq.de/security/code-scanning/1](https://github.com/phpMyFAQ/www.phpmyfaq.de/security/code-scanning/1)

To fix the problem, you should add an explicit `permissions` block to the workflow. Since none of the workflow steps require write access to the repository (they install dependencies, build, run tests, and upload artifacts), the minimum needed permission is `contents: read`. This block can be added at the root of the workflow (before `jobs:`), which will apply to all jobs unless overridden.

Change required: 
- Add the following block between the `on:` block and the `jobs:` block in `.github/workflows/playwright.yml`:
```yaml
permissions:
  contents: read
```
No additional methods, imports, or changes elsewhere are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
